### PR TITLE
fix: missing path override of fs::FileImpl

### DIFF
--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -54,8 +54,10 @@ public:
 	size_t size() const override { return 0; };
 	void close() override {};
 	time_t getLastWrite() override { return 0; };
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
-	const char* path() const override { return "not implemented yet"; };
+#ifdef ESP_IDF_VERSION && ESP_IDF_VERSION_VAL
+	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+		const char* path() const override { return "not implemented yet"; };
+	#endif
 #endif
 	const char* name() const override { return _Name.c_str(); };
 #if   defined(ESP32)

--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -54,7 +54,9 @@ public:
 	size_t size() const override { return 0; };
 	void close() override {};
 	time_t getLastWrite() override { return 0; };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
 	const char* path() const override { return "not implemented yet"; };
+#endif
 	const char* name() const override { return _Name.c_str(); };
 #if   defined(ESP32)
 	boolean isDirectory(void) override { return true; };

--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -54,6 +54,7 @@ public:
 	size_t size() const override { return 0; };
 	void close() override {};
 	time_t getLastWrite() override { return 0; };
+	const char* path() const override { return "not implemented yet"; };
 	const char* name() const override { return _Name.c_str(); };
 #if   defined(ESP32)
 	boolean isDirectory(void) override { return true; };


### PR DESCRIPTION
will fix this issues https://github.com/peterus/ESP-FTP-Server-Lib/issues/12 after updating esp32 platform to 4.x

TODO:
- [x] somehow check platformversion
- [x] fix build