### PR TITLE
Fix for arduino-esp32 #6569

### DIFF
--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -54,9 +54,12 @@ public:
 	size_t size() const override { return 0; };
 	void close() override {};
 	time_t getLastWrite() override { return 0; };
-#ifdef ESP_IDF_VERSION && ESP_IDF_VERSION_VAL
+#if defined ESP_IDF_VERSION && defined ESP_IDF_VERSION_VAL
 	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
 		const char* path() const override { return "not implemented yet"; };
+	#endif
+	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 3)
+		bool setBufferSize(size_t size) override { return false; };
 	#endif
 #endif
 	const char* name() const override { return _Name.c_str(); };


### PR DESCRIPTION
compile error fixed: new function introduced at arduino-esp32 with #6569 (BUGFIX: FS read + speed improvements for SD)