### PR TITLE
fixed compiler error with IDF 4.4.3

### DIFF
--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -58,6 +58,14 @@ public:
 	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
 		const char* path() const override { return "not implemented yet"; };
 	#endif
+	#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 3)
+	    virtual boolean seekDir(long position) override {
+			return false;
+		}
+		virtual String getNextFileName(void) override {
+			return "";
+		}
+	#endif
 	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 3)
 		bool setBufferSize(size_t size) override { return false; };
 	#endif


### PR DESCRIPTION
IDF 4.4.3 is pre-requisit for matter home automation and due to the refactoring of
the espressif arduino-esp32 lib (commit #7229) it will not compile...