### PR TITLE
ARDUINO 2.0.9 fix

### DIFF
--- a/src/FTPFilesystem.h
+++ b/src/FTPFilesystem.h
@@ -65,6 +65,12 @@ public:
 		virtual String getNextFileName(void) override {
 			return "";
 		}
+	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 9)
+		virtual String getNextFileName(bool *isDir) override {
+			*isDir = isDirectory();
+			return getNextFileName();
+		}
+	#endif
 	#endif
 	#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(2, 0, 3)
 		bool setBufferSize(size_t size) override { return false; };


### PR DESCRIPTION
A new variant of getNextFileName introduced with ESP_Ardunio 2.0.9 - see
https://github.com/espressif/arduino-esp32/commit/fa9e0590054049905c5f5ac2178a16879f6fcd10