### PR TITLE
Support of UTF-8

### DIFF
--- a/src/FTPConnection.cpp
+++ b/src/FTPConnection.cpp
@@ -72,7 +72,7 @@ bool FTPConnection::readUntilLineEnd() {
     char c = _Client.read();
     if (c == '\n') {
       uint32_t index_separator = _Line.indexOf(' ');
-      _LineSplited = {_Line.substring(0, index_separator), _Line.substring(index_separator + 1, _Line.length())};
+      _LineSplited             = {_Line.substring(0, index_separator), _Line.substring(index_separator + 1, _Line.length())};
       return true;
     }
     if (c >= 32) {


### PR DESCRIPTION
This is just a proposal. 
With these changes the FTP-Server adds support for UTF-8 and for white-spaces in filenames and folders.
Also Filezille now detects the UTF-8 mode if set to "automatic-detection".

Since UTF-8 is fully supported by Arduino 2 filesystems there should be no problem to enable this.
But it would also be possible to only enable UTF-8 support if you configure it when adding the filesystem.

Thanks a lot for this great FTP-Server! It really works great for me :-) ...