### PR TITLE
Server.available() is deprecated, use Server.accept() instead. Fixees compiler warnings for upcoming Arduino 3

### DIFF
--- a/src/ESP-FTP-Server-Lib.cpp
+++ b/src/ESP-FTP-Server-Lib.cpp
@@ -37,7 +37,7 @@ bool isNotConnected(const std::shared_ptr<FTPConnection> &con) {
 
 void FTPServer::handle() {
   if (_Server.hasClient()) {
-    std::shared_ptr<FTPConnection> connection = std::shared_ptr<FTPConnection>(new FTPConnection(_Server.available(), _UserList, _Filesystem));
+    std::shared_ptr<FTPConnection> connection = std::shared_ptr<FTPConnection>(new FTPConnection(_Server.accept(), _UserList, _Filesystem));
     _Connections.push_back(connection);
   }
   for (std::shared_ptr<FTPConnection> con : _Connections) {


### PR DESCRIPTION
Tested with both profiles ESp32 & ESP8266. Fixes warning

```
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP-FTP-Server-Lib/src/ESP-FTP-Server-Lib.cpp: In member function 'void FTPServer::handle()':
.pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP-FTP-Server-Lib/src/ESP-FTP-Server-Lib.cpp:40:115: warning: 'WiFiClient WiFiServer::available()' is deprecated: Renamed to accept(). [-Wdeprecated-declarations]
   40 |     std::shared_ptr<FTPConnection> connection = std::shared_ptr<FTPConnection>(new FTPConnection(_Server.available(), _UserList, _Filesystem));
      |                                                                                                  ~~~~~~~~~~~~~~~~~^~
In file included from .pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP-FTP-Server-Lib/src/FTPConnection.h:4,
                 from .pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP-FTP-Server-Lib/src/ESP-FTP-Server-Lib.h:7,
                 from .pio/libdeps/lolin_d32_pro_sdmmc_pe/ESP-FTP-Server-Lib/src/ESP-FTP-Server-Lib.cpp:1:
```